### PR TITLE
Fix trailing newline error with patch production

### DIFF
--- a/patch.py
+++ b/patch.py
@@ -6,7 +6,7 @@ def produce_patch_str(mutation: Tuple[str, int, str, str]):
     patch_str = "--- {filename}\n+++ {filename}\n".format(filename=filename)
     patch_str += "@@ -{line_number},1 +{line_number},1 @@\n".format(line_number=line_number)
     patch_str += "-"+old_line+"\n"
-    patch_str += "+"+new_line
+    patch_str += "+"+new_line+"\n"
 
     return patch_str
 


### PR DESCRIPTION
I forgot to add a trailing newline in the patch (whoops) which broke stuff. Should be fixed now.